### PR TITLE
Expanded support for cleverKeys to avoid filtering the selected curves by components

### DIFF
--- a/scripts/cleverKeys.py
+++ b/scripts/cleverKeys.py
@@ -52,7 +52,7 @@ def toggleDebug():
     selectedAttributes.toggleDebug()
 
 
-def setKey(insert=True, useSelectedCurves=True):
+def setKey(insert=True, useSelectedCurves=True, filterCurveByComponent=False):
     '''Sets clever keys.  Hohoho.
 
     If the mouse is over the graph editor, it keys the attributes selected
@@ -63,7 +63,7 @@ def setKey(insert=True, useSelectedCurves=True):
     parameter to false to disable this behavior.'''
 
     # Get Attributes
-    attributes = selectedAttributes.get(detectionType='cursor', useSelectedCurves=useSelectedCurves)
+    attributes = selectedAttributes.get(detectionType='cursor', useSelectedCurves=useSelectedCurves, filterCurveByComponent=filterCurveByComponent)
     currentFrame = cmd.currentTime(q=1)
 
     # Make extra sure attributes are unique (they should already be)


### PR DESCRIPTION
Hey Jordan! 
Here's the thinking behind the update: When selecting curve components in the graph editor (tangents or keys), it would be awesome if cleverKeys treated those selections as "selected curves" when setting new keys. I added the functionality in a way that is "opt-in", so that it leaves everything alone that doesn't call selectedAttributes.get() without that argument. Ie,
cleverKeys.setKey(filterCurveByComponent=True)
I've tested it the best I can and it doesn't interfere with any other modules, afaik.

Would you be able to add this functionality to your master? 

Thank you!